### PR TITLE
Fix off-by-one error in BaseDataProvider

### DIFF
--- a/tf_unet/image_util.py
+++ b/tf_unet/image_util.py
@@ -93,7 +93,7 @@ class BaseDataProvider(object):
     
         X[0] = train_data
         Y[0] = labels
-        for i in range(0, n):
+        for i in range(1, n):
             train_data, labels = self._load_data_and_label()
             X[i] = train_data
             Y[i] = labels


### PR DESCRIPTION
We already copy the first element to the first position in the array. If we start from zero again, we loose the first image, and pull one more element than actually needed.